### PR TITLE
Fix tsconfig alias for shadcn CLI

### DIFF
--- a/dashboard-ts/tsconfig.json
+++ b/dashboard-ts/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.app.json",
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary
- extend `dashboard-ts/tsconfig.json` from `tsconfig.app.json` so shadcn CLI reads the alias

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6849ebc3dc188331bf2ae74205c1361a