### PR TITLE
Document backend modules

### DIFF
--- a/backend-api/init_db.py
+++ b/backend-api/init_db.py
@@ -1,3 +1,5 @@
+"""Script auxiliar para inicializar la base de datos SQLite."""
+
 from sqlmodel import SQLModel, create_engine
 from models import Factura, LineaFactura
 
@@ -5,6 +7,8 @@ sqlite_file = "facturas.db"
 engine = create_engine(f"sqlite:///{sqlite_file}")
 
 def crear_base_de_datos():
+    """Crea las tablas definidas en los modelos."""
+
     SQLModel.metadata.create_all(engine)
     print(f"Base de datos creada: {sqlite_file}")
 

--- a/backend-api/main.py
+++ b/backend-api/main.py
@@ -1,10 +1,17 @@
-from fastapi import FastAPI, File, UploadFile
+"""API principal del backend.
+
+Contiene los endpoints necesarios para recibir facturas, procesar PDFs con
+Google Vision y exponer los datos almacenados en la base de datos. En esta
+aplicación se utiliza SQLite como sistema de persistencia mediante SQLModel.
+"""
+
+from fastapi import Body, FastAPI, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-from fastapi import Body
 from procesamiento.parser_facturas import parse_text_ocr
-import shutil, os
+import os
+import shutil
 
 from google.cloud import vision
 from google.cloud import storage
@@ -29,7 +36,9 @@ engine = create_engine("sqlite:///facturas.db")
 
 @app.post("/factura")
 async def recibir_factura(file: UploadFile = File(...)):
-    # Guardar la imagen recibida
+    """Guardar una imagen de factura y extraer texto con OCR."""
+
+    # Guardar la imagen recibida en disco
     os.makedirs("facturas_recibidas", exist_ok=True)
     file_path = f"facturas_recibidas/{file.filename}"
     with open(file_path, "wb") as buffer:
@@ -55,6 +64,9 @@ async def recibir_factura(file: UploadFile = File(...)):
 
 @app.get("/procesar-factura-pdf")
 def procesar_factura_pdf():
+    """Procesa un PDF de ejemplo alojado en GCS y devuelve datos estructurados."""
+
+    # Funciones auxiliares se importan aquí para evitar dependencias globales
     from ocr_google_document import procesar_pdf_en_gcs, descargar_texto_ocr
 
     ruta_pdf = "gs://facturas-escandaia/pendientes/Factura2206163457.pdf"
@@ -73,6 +85,8 @@ def procesar_factura_pdf():
 
 @app.get("/procesar-pdf-ocr")
 def procesar_factura_pdf(pdf: str):
+    """Procesa el PDF indicado por nombre y devuelve el texto extraído."""
+
     from ocr_google_document import procesar_pdf_en_gcs, descargar_texto_ocr
 
     ruta_pdf = f"gs://facturas-escandaia/pendientes/{pdf}"
@@ -89,6 +103,8 @@ def procesar_factura_pdf(pdf: str):
 
 @app.get("/procesar-nuevos-pdfs")
 def procesar_nuevos_pdfs():
+    """Procesa en lote todos los PDFs pendientes en GCS."""
+
     from ocr_google_document import procesar_pdf_en_gcs, descargar_texto_ocr
     import time
 
@@ -135,6 +151,8 @@ def procesar_nuevos_pdfs():
 
 @app.get("/extraer-datos-de-facturas")
 def extraer_datos_de_facturas():
+    """Descarga los JSON de OCR y extrae la información estructurada."""
+
     from procesamiento.parser_facturas import parse_text_ocr
     from ocr_google_document import descargar_texto_ocr
     from google.cloud import storage
@@ -170,6 +188,8 @@ def extraer_datos_de_facturas():
 
 @app.get("/guardar-datos-en-db")
 def guardar_datos_en_db():
+    """Guarda en la base de datos los datos extraídos de las facturas."""
+
     from procesamiento.parser_facturas import parse_text_ocr
     from ocr_google_document import descargar_texto_ocr
     from google.cloud import storage
@@ -239,6 +259,8 @@ def guardar_datos_en_db():
 
 @app.get("/facturas")
 def listar_facturas():
+    """Devuelve todas las facturas almacenadas ordenadas por fecha."""
+
     from sqlmodel import Session, select
     with Session(engine) as session:
         consulta = select(Factura).order_by(Factura.creada_en.desc())
@@ -247,6 +269,8 @@ def listar_facturas():
 
 @app.get("/lineas-factura/{factura_id}")
 def obtener_lineas_factura(factura_id: int):
+    """Obtiene las líneas de una factura concreta."""
+
     from sqlmodel import Session, select
     with Session(engine) as session:
         consulta = select(LineaFactura).where(LineaFactura.factura_id == factura_id)
@@ -256,6 +280,8 @@ def obtener_lineas_factura(factura_id: int):
 
 @app.post("/facturas")
 def crear_factura(factura: Factura = Body(...)):
+    """Inserta manualmente una factura en la base de datos."""
+
     with Session(engine) as session:
         session.add(factura)
         session.commit()
@@ -264,6 +290,8 @@ def crear_factura(factura: Factura = Body(...)):
 
 @app.get("/facturas/{factura_id}")
 def obtener_factura(factura_id: int):
+    """Obtiene una factura por su ID."""
+
     with Session(engine) as session:
         factura = session.get(Factura, factura_id)
         if not factura:
@@ -273,6 +301,8 @@ def obtener_factura(factura_id: int):
 
 @app.put("/facturas/{factura_id}")
 def actualizar_factura(factura_id: int, datos: dict = Body(...)):
+    """Actualiza campos específicos de una factura existente."""
+
     with Session(engine) as session:
         factura = session.get(Factura, factura_id)
         if not factura:
@@ -290,6 +320,8 @@ def actualizar_factura(factura_id: int, datos: dict = Body(...)):
 
 @app.delete("/facturas/{factura_id}")
 def borrar_factura(factura_id: int):
+    """Elimina una factura de la base de datos."""
+
     with Session(engine) as session:
         factura = session.get(Factura, factura_id)
         if not factura:

--- a/backend-api/models.py
+++ b/backend-api/models.py
@@ -1,8 +1,11 @@
+"""Modelos de base de datos para almacenar facturas y sus líneas."""
+
 from sqlmodel import SQLModel, Field
 from typing import Optional
 from datetime import datetime
 
 class Factura(SQLModel, table=True):
+    """Cabecera de una factura extraída mediante OCR."""
     id: Optional[int] = Field(default=None, primary_key=True)
     nombre_archivo: str
     proveedor: Optional[str]
@@ -12,9 +15,11 @@ class Factura(SQLModel, table=True):
     creada_en: datetime = Field(default_factory=datetime.utcnow)
 
 class LineaFactura(SQLModel, table=True):
+    """Detalle de productos o servicios asociados a una factura."""
     id: Optional[int] = Field(default=None, primary_key=True)
     factura_id: int = Field(foreign_key="factura.id")
     descripcion: str
     cantidad: Optional[float]
     precio_unitario: Optional[float]
     total_linea: Optional[float]
+

--- a/backend-api/ocr_google_document.py
+++ b/backend-api/ocr_google_document.py
@@ -1,8 +1,12 @@
+"""Utilidades para ejecutar OCR sobre PDFs almacenados en Google Cloud Storage."""
+
 from google.cloud import vision_v1 as vision
 from google.cloud.vision_v1 import types
 import time
 
 def procesar_pdf_en_gcs(gcs_input_uri: str):
+    """Lanza un trabajo asíncrono de OCR sobre un PDF en GCS."""
+
     client = vision.ImageAnnotatorClient()
 
     # Configuración de OCR
@@ -37,8 +41,11 @@ from google.cloud import storage
 import json
 
 def descargar_texto_ocr(gcs_output_uri: str):
+    """Descarga el archivo JSON resultante del OCR y devuelve el texto completo."""
+
     # gcs_output_uri = 'gs://bucket/nombre_output/'
     bucket_name = gcs_output_uri.replace("gs://", "").split("/")[0]
+    # Carpeta donde vision guardó los resultados
     prefix = "/".join(gcs_output_uri.replace("gs://", "").split("/")[1:])
 
     storage_client = storage.Client()
@@ -59,3 +66,4 @@ def descargar_texto_ocr(gcs_output_uri: str):
     full_text = data["responses"][0]["fullTextAnnotation"]["text"]
 
     return full_text
+

--- a/backend-api/procesamiento/parser_facturas.py
+++ b/backend-api/procesamiento/parser_facturas.py
@@ -1,7 +1,12 @@
+"""Heurísticas para extraer datos estructurados de una factura a partir del
+texto devuelto por OCR."""
+
 import re
 from datetime import datetime
 
 def parse_text_ocr(texto: str) -> dict:
+    """Convierte el texto plano de una factura en un diccionario de datos."""
+
     proveedor = None
     fecha = None
     numero_factura = None
@@ -13,6 +18,7 @@ def parse_text_ocr(texto: str) -> dict:
 
     # --- Proveedor ---
     for linea in lineas[:15]:
+        # Buscamos indicios de nombre de empresa en las primeras líneas
         if any(palabra in linea.lower() for palabra in ["s.l", "slu", "sociedad", "distribuciones", "paruben", "asador"]):
             proveedor = linea.strip()
             break
@@ -62,6 +68,7 @@ def parse_text_ocr(texto: str) -> dict:
         sig = lineas[i+1].strip() if i+1 < len(lineas) else ""
 
         # Si la línea parece descripción y la siguiente contiene precio
+        # Consideramos que es un producto si la línea es texto y la siguiente tiene precios
         if re.search(r"[A-Za-z]{3,}", linea) and re.search(r"\d+,\d{2}", sig):
             descripcion = linea
             posibles_numeros = re.findall(r"\d+,\d{2}", sig)
@@ -85,3 +92,4 @@ def parse_text_ocr(texto: str) -> dict:
         "productos": productos,
         "total": float(total) if total else None
     }
+


### PR DESCRIPTION
## Summary
- document all backend modules
- add inline explanations for OCR parsing logic
- include docstrings for endpoints and database models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6852758e4474833188d327f614e4fcf8